### PR TITLE
fixed datathon final page image and changed note to fb link

### DIFF
--- a/events/DataSoc_Datathon_Final.html
+++ b/events/DataSoc_Datathon_Final.html
@@ -46,14 +46,14 @@
                     <div class="columns is-vcentered">
                         <div class="column is-6">
                             <figure class="">
-                                <img src="../assets/images/events/hackathon.png">
+                                <img src="../assets/images/events/datathon_final.jpg>
                             </figure>
                         </div>
                         <div class="column is-6 is-pulled-right">
                         <h3 class="is-hero-title subtitle has-text-right">
                             <b>Date:</b> <br>4th - 5th September 2019
                             <br> <br>
-                            <b>Note:</b> <br>Note: Local undergraduate and postgraduate students are free to enter from any Australian university, however transportation will not be provided by DataSoc for students from other regions of Australia.
+                            <a href="https://www.facebook.com/events/680034919089423/"><b>Facebook Event Link</b></a>
                             <br> <br>
                             For more information email: hello@unswdata.com
                         </h3>


### PR DESCRIPTION
I've updated the image on /events/DataSoc_Datathon_Final to be the new cover photo, and replaced the 'Note' with the link to the FB page.